### PR TITLE
Update fetcher.js

### DIFF
--- a/src/utils/fetcher.js
+++ b/src/utils/fetcher.js
@@ -125,6 +125,16 @@ export async function fetchPackageDetails(name, result) {
                     : versionInfo.repository || ''
         }
 
+        if (!packageLinks.bugs) {
+            delete packageLinks.bugs;
+        }
+        if (!packageLinks.homepage) {
+            delete packageLinks.homepage;
+        }
+        if (!packageLinks.repository) {
+            delete packageLinks.repository;
+        }
+
         const isVerified = isVerifiedPackage(name)
         const shortname = getPackageShortname(name)
 


### PR DESCRIPTION
目前对于未指定homepage、bugs的koishi插件，镜像里仍存在homepage、bugs字段。导致插件市场点击这些未指定homepage、bugs的koishi插件的时候 出现【新标签页打开当前页面】的效果。

应当将无效的homepage、bugs移除。