### PR TITLE
Update fetcher.js - 对 `versionInfo.contributors` 添加类型检查

### DIFF
--- a/src/utils/fetcher.js
+++ b/src/utils/fetcher.js
@@ -97,19 +97,19 @@ export async function fetchPackageDetails(name, result) {
             username: maintainer.name || ''
         }))
 
-        const contributors = (versionInfo.contributors || []).map(
-            (contributor) => {
-                if (typeof contributor === 'string') {
-                    return { name: contributor }
-                }
-                return {
-                    name: contributor.name || '',
-                    email: contributor.email || '',
-                    url: contributor.url || '',
-                    username: contributor.name || ''
-                }
-            }
-        )
+        const contributors = Array.isArray(versionInfo.contributors) ? versionInfo.contributors.map(
+          (contributor) => {
+              if (typeof contributor === 'string') {
+                  return { name: contributor }
+              }
+              return {
+                  name: contributor.name || '',
+                  email: contributor.email || '',
+                  url: contributor.url || '',
+                  username: contributor.name || ''
+              }
+          }
+      ) : [];      
 
         const npmLink = name.startsWith('@')
             ? `${config.NPM_PACKAGE_URL}/${name}`


### PR DESCRIPTION
修改效果：

确保 `versionInfo.contributors` 是一个数组。 如果不是数组，则将其赋值为一个空数组 `[]`，从而避免 `TypeError`。

---

源代码使用 `(versionInfo.contributors || [])`，

但是如果 `versionInfo.contributors` 存在 但不是一个数组，例如是一个字符串、null、undefined 或其他非数组类型的值，

那么这段代码仍然会尝试对这个非数组类型的值调用 `.map` 方法，

从而导致 `TypeError: (versionInfo.contributors || []).map is not a function` 错误。

---

实际案例：

->  https://www.npmjs.com/package/koishi-plugin-dew-bot/v/1.0.141?activeTab=code

此插件的npm最新版本 1.0.141 的`package.json`中写的内容为
```
{
  "name": "koishi-plugin-dew-bot",
  "description": "达尔文进化岛",
  "preview": true,
  "version": "1.0.141",
  "main": "lib/index.js",
  "typings": "lib/index.d.ts",
  "contributors": "楚轩<3245000000@qq.com>",
  "homepage": "主页",
  "files": [
    "lib",
    "dist"
  ],
  "license": "MIT",
  "scripts": {
    "copy-assets": "copyfiles -u 1 src/**/*.{html,css,font,ttf} lib/",
    "prepub": "npm version patch",
    "pub": "npm publish --access public"
  },
  "keywords": [
    "chatbot",
    "koishi",
    "plugin"
  ],
  "devDependencies": {
    "@koishijs/client": "^5.30.7",
    "handlebars": "^4.7.8",
    "tsrpc": "^3.4.17"
  },
  "peerDependencies": {
    "@koishijs/plugin-console": "^5.30.7",
    "handlebars": "^4.7.8",
    "koishi": "^4.18.7"
  }
}
```


其中就有 `  "contributors": "楚轩<3245000000@qq.com>",`  内容

这就会导致上述的错误。

---


这在 koishi-plugin-storeluna 插件中遇到了此问题，并且修复了。

```
2025-04-03 14:36:40 [I] storeluna storeluna 当前为 NPM 更新模式，将从 NPM 获取数据并更新本地文件。
2025-04-03 14:36:40 [I] storeluna 即将从npm地址拉取内容，请不要重载插件！
2025-04-03 14:36:43 [E] storeluna Error fetching koishi-plugin-dew-bot: TypeError: (versionInfo.contributors || []).map is not a function at fetchPackageDetails (D:\QQbots\QQ_bots\koishing\coding\koishi-c\koishi-app\external\koishi-shangxue-apps\plugins\storeluna\lib\index.js:352:61)     at process.processTicksAndRejections (node:internal/process/task_queues:105:5) at async Promise.all (index 199) at async fetchKoishiPlugins (D:\QQbots\QQ_bots\koishing\coding\koishi-c\koishi-app\external\koishi-shangxue-apps\plugins\storeluna\lib\index.js:511:28) at async updateDataFromNPM (D:\QQbots\QQ_bots\koishing\coding\koishi-c\koishi-app\external\koishi-shangxue-apps\plugins\storeluna\lib\index.js:683:21)
2025-04-03 14:36:48 [W] qq offline: server request reconnect
2025-04-03 14:36:48 [W] adapter Session timed out, will retry in 5s...
2025-04-03 14:36:54 [I] adapter connect to server: wss://api.sgroup.qq.com/websocket
2025-04-03 14:36:58 [I] storeluna 进度: 250/2805 | 已收录: 231
2025-04-03 14:37:01 [I] storeluna 进度: 500/2805 | 已收录: 466
2025-04-03 14:37:03 [I] storeluna 进度: 750/2805 | 已收录: 699
2025-04-03 14:37:06 [I] storeluna 进度: 1000/2805 | 已收录: 917
2025-04-03 14:37:08 [I] storeluna 进度: 1250/2805 | 已收录: 1134
2025-04-03 14:37:09 [I] storeluna 进度: 1500/2805 | 已收录: 1353
2025-04-03 14:37:10 [I] storeluna 进度: 1750/2805 | 已收录: 1554
2025-04-03 14:37:11 [I] storeluna 进度: 2000/2805 | 已收录: 1740
2025-04-03 14:37:12 [I] storeluna 进度: 2250/2805 | 已收录: 1923
2025-04-03 14:37:13 [I] storeluna 进度: 2500/2805 | 已收录: 2104
2025-04-03 14:37:14 [I] storeluna 进度: 2750/2805 | 已收录: 2325
2025-04-03 14:37:14 [I] storeluna 进度: 2805/2805 | 已收录: 2378
2025-04-03 14:37:14 [I] storeluna
                        扫描完成：
2025-04-03 14:37:14 [I] storeluna - 总扫描数量: 2805
2025-04-03 14:37:14 [I] storeluna - 最终收录: 2378
2025-04-03 14:37:14 [I] storeluna 过滤完成，原始插件数：2378 → 当前插件数：2378
2025-04-03 14:37:14 [I] storeluna 数据已保存到文件, 绝对路径：D:\QQbots\QQ_bots\koishing\coding\koishi-c\koishi-app\data\storeluna\index.json
2025-04-03 14:37:14 [I] storeluna 从 NPM 同步成功，插件总数：2378
```



故 回到这里 PR 一下。
