### PR TITLE
增加对插件的npmjs原地址验证逻辑

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "mongodb": "^6.12.0",
     "node-cron": "^3.0.3",
     "node-fetch": "^3.3.2",
+    "p-limit": "^6.2.0",
     "semver": "^7.6.3"
   },
   "devDependencies": {

--- a/src/config.js
+++ b/src/config.js
@@ -27,7 +27,10 @@ const defaults = {
         'https://koishi-registry.github.io/categories/bundle.json',
 
     INSECURE_PACKAGES_URL:
-        'https://koishi-registry.github.io/insecures/index.json'
+        'https://koishi-registry.github.io/insecures/index.json',
+
+    INCREMENTAL_UPDATE: "false", // 是否开启增量更新，否则每次都全量扫描
+    NPMJS_CONCURRENT_REQUESTS: 80, // npmjs.org 官方源的并发请求限制
 }
 
 // 导出最终配置
@@ -42,7 +45,7 @@ export const config = {
     MAX_RETRIES: parseInt(process.env.MAX_RETRIES || defaults.MAX_RETRIES),
     OPTIMAL_WORKERS_MULTIPLIER: parseInt(
         process.env.OPTIMAL_WORKERS_MULTIPLIER ||
-            defaults.OPTIMAL_WORKERS_MULTIPLIER
+        defaults.OPTIMAL_WORKERS_MULTIPLIER
     ),
 
     // 数据库配置
@@ -67,5 +70,10 @@ export const config = {
         process.env.CATEGORIES_API_URL || defaults.CATEGORIES_API_URL,
 
     INSECURE_PACKAGES_URL:
-        process.env.INSECURE_PACKAGES_URL || defaults.INSECURE_PACKAGES_URL
+        process.env.INSECURE_PACKAGES_URL || defaults.INSECURE_PACKAGES_URL,
+
+    INCREMENTAL_UPDATE: process.env.INCREMENTAL_UPDATE
+        ? process.env.INCREMENTAL_UPDATE.toLowerCase() === 'true'
+        : defaults.INCREMENTAL_UPDATE === 'true',
+    NPMJS_CONCURRENT_REQUESTS: parseInt(process.env.NPMJS_CONCURRENT_REQUESTS || defaults.NPMJS_CONCURRENT_REQUESTS, 10),
 }

--- a/src/scanner.js
+++ b/src/scanner.js
@@ -43,26 +43,19 @@ export async function scanOnly() {
         const collection = await getPluginsCollection()
         const existingCount = await collection.countDocuments()
 
-        if (existingCount === 0) {
-            console.log('数据库为空，执行全量扫描...')
-            const plugins = await fetchKoishiPlugins()
-            if (plugins.length) {
-                await saveToDatabase(plugins)
-                await saveToFile(plugins)
-                console.log(`扫描完成，已保存 ${plugins.length} 个插件`)
-            }
-        } else {
-            console.log('执行增量更新...')
-            const updatedCount = await checkForUpdates()
-            const allPlugins = await loadFromDatabase()
-            await saveToFile(allPlugins)
-            console.log(
-                `更新完成，更新了 ${updatedCount} 个插件，总共 ${allPlugins.length} 个插件`
-            )
-        }
+        // 无论是否增量更新，都直接调用 checkForUpdates
+        // checkForUpdates 内部会根据配置判断是否清空数据库或执行增量逻辑
+        console.log('执行更新/扫描...')
+        const updatedCount = await checkForUpdates()
+        const allPlugins = await loadFromDatabase()
+        await saveToFile(allPlugins)
+        console.log(
+            `更新完成，更新了 ${updatedCount} 个插件，总共 ${allPlugins.length} 个插件`
+        )
     } catch (error) {
         console.error('扫描插件数据时出错:', error)
     } finally {
         await closeDB()
     }
 }
+

--- a/src/server.js
+++ b/src/server.js
@@ -19,7 +19,7 @@ export class Server {
     async updateData() {
         console.log('正在从数据库更新数据...')
         try {
-            const updatedCount = await checkForUpdates()
+            const totalChanges = await checkForUpdates()
             const plugins = await loadFromDatabase()
 
             this.data = {
@@ -30,7 +30,7 @@ export class Server {
             }
 
             console.log(
-                `数据更新完成，更新了 ${updatedCount} 个插件，总共 ${plugins.length} 个插件`
+                `数据更新完成，共发生 ${totalChanges} 处变化 (新增/更新/移除)，当前总共 ${plugins.length} 个插件`
             )
         } catch (error) {
             console.error('更新数据时出错:', error)

--- a/src/utils/update.js
+++ b/src/utils/update.js
@@ -6,7 +6,18 @@ import semver from 'semver'
 import { loadInsecurePackages } from './insecure.js'
 
 export async function checkForUpdates() {
+    // 记录开始时间
+    const startTime = process.hrtime.bigint(); // 使用高精度时间，避免毫秒级误差
     const collection = await getPluginsCollection()
+    let updatedCount = 0
+    let removedCount = 0
+
+    if (!config.INCREMENTAL_UPDATE) {
+        console.log('配置为全量更新，正在清空数据库...')
+        await collection.deleteMany({}) // 清空所有文档
+        console.log('数据库已清空。')
+    }
+
     const params = new URLSearchParams({
         text: config.SEARCH_QUERY,
         size: config.SEARCH_SIZE,
@@ -20,10 +31,49 @@ export async function checkForUpdates() {
         loadInsecurePackages()
     ])
 
-    let updatedCount = 0
+    console.log('正在验证数据库中现有插件的 npmjs 官方源可用性...')
+    const existingPluginsCheckPromises = existingPlugins.map(async (plugin) => {
+        const packageName = plugin.package.name
+        const npmjsOfficialUrl = `https://registry.npmjs.org/${packageName}`
+        try {
+            // 使用 HEAD 请求，只获取头部信息
+            const officialResponse = await fetchWithRetry(npmjsOfficialUrl, { method: 'HEAD' }, 5, false, true);
+
+            if (officialResponse.status === 404) {
+                console.log(`Package ${packageName} not found on npmjs.org, marking for removal.`);
+                return { name: packageName, status: 'removed' };
+            }
+            if (!officialResponse.ok) {
+                // 如果不是 404，但也不是 2xx，可能是其他错误，记录警告但不移除
+                console.warn(`Warning: npmjs.org returned status ${officialResponse.status} for existing package ${packageName}.`);
+                return { name: packageName, status: 'removed' };
+                // 移除掉
+            }
+            return { name: packageName, status: 'ok' };
+        } catch (error) {
+            console.warn(`Error checking npmjs.org for existing package ${packageName}: ${error.message}. Marking for removal.`);
+            return { name: packageName, status: 'removed' };
+        }
+    });
+    const existingPluginsCheckResults = await Promise.all(existingPluginsCheckPromises);
+    const packagesToRemove = existingPluginsCheckResults
+        .filter(result => result.status === 'removed')
+        .map(result => result.name);
+
+    if (packagesToRemove.length > 0) {
+        console.log(`正在从数据库中移除 ${packagesToRemove.length} 个在 npmjs.org 上已不存在的包...`);
+        const deleteResult = await collection.deleteMany({ 'package.name': { $in: packagesToRemove } });
+        removedCount += deleteResult.deletedCount;
+        console.log(`已移除 ${deleteResult.deletedCount} 个包。`);
+    } else {
+        // console.log('所有现有插件在 npmjs.org 上均可用。');
+    }
+
+    // 重新获取现有插件列表，因为可能已经移除了部分
+    const currentExistingPlugins = await collection.find({}).toArray();
 
     // 首先检查并更新现有插件的安全状态
-    const securityUpdateOps = existingPlugins
+    const securityUpdateOps = currentExistingPlugins
         .map((plugin) => {
             const isCurrentlyInsecure = plugin.insecure || false
             const shouldBeInsecure = insecurePackages.has(plugin.package.name)
@@ -53,9 +103,9 @@ export async function checkForUpdates() {
         await collection.bulkWrite(securityUpdateOps)
     }
 
-    // 创建现有版本的映射
+    // 创建现有版本的映射 (基于重新获取的列表)
     const existingVersions = new Map(
-        existingPlugins.map((plugin) => [
+        currentExistingPlugins.map((plugin) => [
             plugin.package.name,
             plugin.package.version
         ])
@@ -72,7 +122,8 @@ export async function checkForUpdates() {
         const latestVersion = result.package.version
         const currentVersion = existingVersions.get(packageName)
 
-        if (!currentVersion || semver.gt(latestVersion, currentVersion)) {
+        // 如果是全量更新模式，或者包是新增的，或者版本有更新，则加入待更新列表
+        if (!config.INCREMENTAL_UPDATE || !currentVersion || semver.gt(latestVersion, currentVersion)) {
             packagesToUpdate.push({
                 name: packageName,
                 version: latestVersion,
@@ -85,12 +136,13 @@ export async function checkForUpdates() {
         }
     }
 
-    if (packagesToUpdate.length === 0) {
-        console.log('没有需要更新的包')
+    if (packagesToUpdate.length === 0 && removedCount === 0) { // 检查是否有移除的包
+        console.log('没有需要更新或移除的包')
         return 0
     }
 
     // 并行获取需要更新的包的详细信息
+    // fetchPackageDetails 内部会再次验证 npmjs 官方源，确保新增/更新的包也有效
     const updatesPromises = packagesToUpdate.map(async (p) => {
         return await fetchPackageDetails(p.name, p.result, insecurePackages)
     })
@@ -114,14 +166,21 @@ export async function checkForUpdates() {
             const currentVersion = existingVersions.get(update.package.name)
             const action = currentVersion ? '更新' : '新增'
             console.log(
-                `- ${action}: ${update.package.name}@${update.package.version}${
-                    currentVersion ? ` (原版本: ${currentVersion})` : ''
+                `- ${action}: ${update.package.name}@${update.package.version}${currentVersion ? ` (原版本: ${currentVersion})` : ''
                 }`
             )
         })
     } else {
-        console.log('没有有效的包需要更新')
+        console.log('没有有效的包需要新增或更新。')
     }
 
-    return updates.length + updatedCount // 返回总更新数量
+    // 记录结束时间
+    const endTime = process.hrtime.bigint();
+    const durationNs = endTime - startTime;
+    const durationMs = Number(durationNs) / 1_000_000; // 转换为毫秒
+    const durationSeconds = durationMs / 1000; // 转换为秒
+
+    console.log(`本次数据库更新总耗时：${durationSeconds.toFixed(2)} 秒`);
+
+    return updates.length + updatedCount + removedCount // 返回总更新/移除数量
 }


### PR DESCRIPTION
部分包在npmminnor镜像源上可用，但是实际在npmjs官网上已经删库

所以增加了对npmjs原地址验证逻辑，这样处理出来的json数据与原数据有较为明显的差距（约100个插件）。

---

插件对比：

原镜像源：

![image](https://github.com/user-attachments/assets/f4e475ea-d22c-4f29-bc2a-a5165ae71085)


修改内容后运行的镜像源：

![image](https://github.com/user-attachments/assets/bd4f2f38-ff49-4a71-ad23-aa6985ec168c)


---

- 增加对插件包的npmjs地址验证逻辑
- 增加模式切换：增量更新模式、全量扫描模式
- 增加对npmjs地址验证时的并行限制
- 增加请求过程计时的日志输出


---


> 啊呜 github的commit更改对比怎么怪怪的，全变成修改内容了。但是明明没修改那么多的（（（

---

本地测试运行日志：


全量扫描模式：

<details>
<summary>运行日志</summary>

```

D:\QQbots\QQ_bots\koishing\coding\koishi-a\others\koishi-registry>npm run start

> koishi-registry@1.0.0 start
> node src/index.js --server

正在从数据库更新数据...
服务器启动在 http://0.0.0.0:3000
定时任务已设置: */10 * * * *
数据库连接成功
配置为全量更新，正在清空数据库...
数据库已清空。
正在验证数据库中现有插件的 npmjs 官方源可用性...
Package @yunkuangao/koishi-plugin-recipe not found on npmjs.org, skipping.
Package @yunkuangao/koishi-plugin-jre not found on npmjs.org, skipping.
Package @eosrce/koishi-plugin-ping not found on npmjs.org, skipping.
Package @yunkuangao/koishi-plugin-meme not found on npmjs.org, skipping.
Package @nyable/koishi-plugin-message-recorder not found on npmjs.org, skipping.
Package @ling121/koishi-plugin-karinsay not found on npmjs.org, skipping.
Package @shangxueink/koishi-plugin-localpics_to_qqurls not found on npmjs.org, skipping.
Package @xiaomoinfo/koishi-plugin-tyq not found on npmjs.org, skipping.
Package @stivine/koishi-plugin-zvv not found on npmjs.org, skipping.
Package @yunkuangao/koishi-plugin-holiday not found on npmjs.org, skipping.
Package @xiaomoinfo/koishi-plugin-adapter-dingtalk not found on npmjs.org, skipping.
Package @myrtus/koishi-plugin-ping not found on npmjs.org, skipping.
Package @myrtus/koishi-plugin-getselfid not found on npmjs.org, skipping.
Package @yunkuangao/koishi-plugin-barotrauma not found on npmjs.org, skipping.
Package @yunkuangao/koishi-plugin-valheim not found on npmjs.org, skipping.
Package @myrtus/koishi-plugin-getgroupid not found on npmjs.org, skipping.
Package @fqianqian/koishi-plugin-license not found on npmjs.org, skipping.
Package @yyyhf/koishi-plugin-eve-server-status not found on npmjs.org, skipping.
Package @sunnypai/koishi-plugin-milvus not found on npmjs.org, skipping.
Package @starfreedomx/koishi-plugin-bang-song-guess not found on npmjs.org, skipping.
Package @xiongcj/koishi-plugin-adapter-wechat4u-persional not found on npmjs.org, skipping.
Package @shangxueink/koishi-plugin-commands-refresh not found on npmjs.org, skipping.
更新了 2528 个有效包:
- 新增: koishi-plugin-dataview@2.7.8
- 新增: koishi-plugin-gocqhttp@3.8.1
- 新增: koishi-plugin-desktop@1.0.0
- 新增: koishi-plugin-puppeteer@3.9.0
- 新增: koishi-plugin-assets-local@3.3.2
- 新增: koishi-plugin-theme-vanilla@1.1.0
- 新增: @koishijs/plugin-console@5.30.7
- 新增: @koishijs/plugin-admin@1.4.0
- 新增: @koishijs/plugin-help@2.4.5
- 新增: @koishijs/plugin-server@3.2.4
- ...
- ...
- ...
- ...
- ...
- ...
- 新增: koishi-plugin-draw-picture@0.0.1
- 新增: koishi-plugin-idv-rank-stats@0.0.3
- 新增: koishi-plugin-yzxgxt@1.0.0
本次数据库更新总耗时：31.33 秒
数据更新完成，共发生 2528 处变化 (新增/更新/移除)，当前总共 2528 个插件


```

没有完整日志，因为 ->

![34bb90f00aecf389d40f9390298ff843](https://github.com/user-attachments/assets/5cde7be1-7592-43bf-8c82-3fe4d2f1c615)

</details>



---


增量更新模式：

<details>
<summary>运行日志</summary>


```

D:\QQbots\QQ_bots\koishing\coding\koishi-a\others\koishi-registry>npm run start

> koishi-registry@1.0.0 start
> node src/index.js --server

正在从数据库更新数据...
服务器启动在 http://0.0.0.0:3000
定时任务已设置: */10 * * * *
数据库连接成功
正在验证数据库中现有插件的 npmjs 官方源可用性...
更新包 koishi-plugin-insecure 的安全状态: 安全
Package @yunkuangao/koishi-plugin-jre not found on npmjs.org, skipping.
Package @eosrce/koishi-plugin-ping not found on npmjs.org, skipping.
Package @yunkuangao/koishi-plugin-meme not found on npmjs.org, skipping.
Package @yunkuangao/koishi-plugin-recipe not found on npmjs.org, skipping.
Package @nyable/koishi-plugin-message-recorder not found on npmjs.org, skipping.
Package @ling121/koishi-plugin-karinsay not found on npmjs.org, skipping.
Package @shangxueink/koishi-plugin-localpics_to_qqurls not found on npmjs.org, skipping.
Package @yunkuangao/koishi-plugin-holiday not found on npmjs.org, skipping.
Package @xiaomoinfo/koishi-plugin-adapter-dingtalk not found on npmjs.org, skipping.
Package @myrtus/koishi-plugin-ping not found on npmjs.org, skipping.
Package @stivine/koishi-plugin-zvv not found on npmjs.org, skipping.
Package @myrtus/koishi-plugin-getselfid not found on npmjs.org, skipping.
Package @xiaomoinfo/koishi-plugin-tyq not found on npmjs.org, skipping.
Package @yunkuangao/koishi-plugin-valheim not found on npmjs.org, skipping.
Package @myrtus/koishi-plugin-getgroupid not found on npmjs.org, skipping.
Package @fqianqian/koishi-plugin-license not found on npmjs.org, skipping.
Package @yyyhf/koishi-plugin-eve-server-status not found on npmjs.org, skipping.
Package @yunkuangao/koishi-plugin-barotrauma not found on npmjs.org, skipping.
Package @sunnypai/koishi-plugin-milvus not found on npmjs.org, skipping.
Package @starfreedomx/koishi-plugin-bang-song-guess not found on npmjs.org, skipping.
Package @xiongcj/koishi-plugin-adapter-wechat4u-persional not found on npmjs.org, skipping.
Package @shangxueink/koishi-plugin-commands-refresh not found on npmjs.org, skipping.
没有有效的包需要新增或更新。
本次数据库更新总耗时：34.40 秒
数据更新完成，共发生 1 处变化 (新增/更新/移除)，当前总共 2528 个插件

```

</details>

---



