### PR TITLE
Update fetcher.js

### DIFF
--- a/src/utils/fetcher.js
+++ b/src/utils/fetcher.js
@@ -137,7 +137,7 @@ export async function fetchPackageDetails(name, result) {
         }
 
         const koishiManifest = versionInfo.koishi || pkgData.koishi || {}
-        if (koishiManifest.hidden === true) {
+        if (koishiManifest.hidden === true || koishiManifest.description?.hidden !== undefined) {
             return null
         }
 


### PR DESCRIPTION
优化处理情况

https://www.npmjs.com/package/koishi-plugin-autoreplyimage?activeTab=code

在这个插件的package.json里

我们发现
```
{
  "name": "koishi-plugin-autoreplyimage",
  "koishi": {
    "description": {
      "en": "English Description",
      "zh": "一个自己用的插件，看到了请无视",
      "hidden": false
    },
    "service": {
      "required": [
        "database"
      ],
      "optional": [
        "assets"
      ],
      "implements": [
        "dialogue"
      ]
    }
  },
  "description": " autoreplyimage",
  "version": "0.0.2",
  "main": "lib/index.js",
  "typings": "lib/index.d.ts",
  "files": [
    "lib",
    "dist"
  ],
  "license": "MIT",
  "scripts": {},
  "keywords": [
    "chatbot",
    "koishi",
    "plugin"
  ],
  "devDependencies": {},
  "peerDependencies": {
    "koishi": "^4.18.7"
  }
}
```
正确内容应该是
```
  "koishi": {
    "description": {
      "en": "English Description",
      "zh": "一个自己用的插件，看到了请无视"
    },
    "hidden": false, // hidden 应该在这里
    "service": {
      "required": [
        "database"
      ],
      "optional": [
        "assets"
      ],
      "implements": [
        "dialogue"
      ]
    }
  },

```

---

这种错误的写法被放到了镜像源里 会导致使用了此镜像源的插件市场出现白屏报错


具体问题反馈+定位经过，请见【590104798】Koishi 非官方交流群