### PR TITLE
新增： 支持指定运行若干次增量更新后，进行一次全量更新

### DIFF
--- a/.github/workflows/Update-Market.yml
+++ b/.github/workflows/Update-Market.yml
@@ -1,26 +1,18 @@
-name: Update Market Test
+name: Update Market
 
 on:
     schedule:
-        - cron: '*/15 * * * *' # 每15分钟运行一次
+        - cron: '*/15 * * * *' # 每10分钟运行一次
     push:
         branches:
-            - beta
-    workflow_dispatch: # 手动触发
+            - main
 
 jobs:
     update-market:
         runs-on: ubuntu-latest
-        services:
-            mongodb:
-                image: mongo:4.4
-                ports:
-                    - 27017:27017
         steps:
             - name: Checkout Repository
               uses: actions/checkout@v4
-              with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Setup Node.js
               uses: actions/setup-node@v4
@@ -31,55 +23,53 @@ jobs:
               run: |
                   corepack enable
                   corepack use yarn
+
+            - name: Setup SSH
+              env:
+                  DEPLOY_KEY: ${{ secrets.DEPLOY_PRIVATE_KEY }}
+              run: |
+                  mkdir -p ~/.ssh/
+                  echo "$DEPLOY_KEY" > ~/.ssh/id_rsa
+                  chmod 600 ~/.ssh/id_rsa
+                  ssh-keyscan github.com >> ~/.ssh/known_hosts
+
             - name: Setup Market
               run: |
                   yarn
+
             - name: Configure Git
+              env:
+                  GIT_USER_NAME: ${{ secrets.GIT_USER_NAME }}
+                  GIT_USER_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
               run: |
-                  git config --global user.name "github-actions[bot]"
-                  git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+                  git config --global user.name "$GIT_USER_NAME"
+                  git config --global user.email "$GIT_USER_EMAIL"
+
             - name: Sync
               env:
-                  MONGODB_URI: mongodb://localhost:27017
+                  MONGODB_URI: ${{ secrets.MONGODB_URI }}
                   CATEGORIES_API_BASE: ${{ secrets.CATEGORIES_API_BASE }}
-                  INCREMENTAL_UPDATE: "true"
-                  INCREMENTAL_UPDATE_TIMES: "3"
               run: |
                   yarn scan
+
             - name: Deploy to Pages Branch
               env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   CUSTOM_DOMAIN: ${{ secrets.CUSTOM_DOMAIN }}
               run: |
                   cp public/index.json /tmp/index.json
-                  
-                  # 如果存在更新计数器文件，也保存它
-                  if [ -f .update-counter ]; then
-                    cp .update-counter /tmp/.update-counter
-                  fi
 
                   git checkout --orphan pages
                   git reset --hard
 
                   cp /tmp/index.json index.json
-                  
-                  # 恢复更新计数器文件
-                  if [ -f /tmp/.update-counter ]; then
-                    cp /tmp/.update-counter .update-counter
-                  fi
 
                   echo "" > .nojekyll
-                  if [ -n "$CUSTOM_DOMAIN" ]; then
-                    echo "$CUSTOM_DOMAIN" > CNAME
-                  fi
-                  git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+
+                  echo "$CUSTOM_DOMAIN" > CNAME
+
+                  git remote set-url origin git@github.com:${GITHUB_REPOSITORY}.git
+
                   git add -f index.json .nojekyll
-                  # 添加更新计数器文件
-                  if [ -f .update-counter ]; then
-                    git add -f .update-counter
-                  fi
-                  if [ -f CNAME ]; then
-                    git add -f CNAME
-                  fi
+                  git add -f index.json CNAME .nojekyll
                   git commit -m "Update market" || true
                   git push -f origin pages

--- a/.github/workflows/Update-Market.yml
+++ b/.github/workflows/Update-Market.yml
@@ -1,18 +1,26 @@
-name: Update Market
+name: Update Market Test
 
 on:
     schedule:
-        - cron: '*/15 * * * *' # 每10分钟运行一次
+        - cron: '*/15 * * * *' # 每15分钟运行一次
     push:
         branches:
-            - main
+            - beta
+    workflow_dispatch: # 手动触发
 
 jobs:
     update-market:
         runs-on: ubuntu-latest
+        services:
+            mongodb:
+                image: mongo:4.4
+                ports:
+                    - 27017:27017
         steps:
             - name: Checkout Repository
               uses: actions/checkout@v4
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Setup Node.js
               uses: actions/setup-node@v4
@@ -23,53 +31,55 @@ jobs:
               run: |
                   corepack enable
                   corepack use yarn
-
-            - name: Setup SSH
-              env:
-                  DEPLOY_KEY: ${{ secrets.DEPLOY_PRIVATE_KEY }}
-              run: |
-                  mkdir -p ~/.ssh/
-                  echo "$DEPLOY_KEY" > ~/.ssh/id_rsa
-                  chmod 600 ~/.ssh/id_rsa
-                  ssh-keyscan github.com >> ~/.ssh/known_hosts
-
             - name: Setup Market
               run: |
                   yarn
-
             - name: Configure Git
-              env:
-                  GIT_USER_NAME: ${{ secrets.GIT_USER_NAME }}
-                  GIT_USER_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
               run: |
-                  git config --global user.name "$GIT_USER_NAME"
-                  git config --global user.email "$GIT_USER_EMAIL"
-
+                  git config --global user.name "github-actions[bot]"
+                  git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
             - name: Sync
               env:
-                  MONGODB_URI: ${{ secrets.MONGODB_URI }}
+                  MONGODB_URI: mongodb://localhost:27017
                   CATEGORIES_API_BASE: ${{ secrets.CATEGORIES_API_BASE }}
+                  INCREMENTAL_UPDATE: "true"
+                  INCREMENTAL_UPDATE_TIMES: "3"
               run: |
                   yarn scan
-
             - name: Deploy to Pages Branch
               env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   CUSTOM_DOMAIN: ${{ secrets.CUSTOM_DOMAIN }}
               run: |
                   cp public/index.json /tmp/index.json
+                  
+                  # 如果存在更新计数器文件，也保存它
+                  if [ -f .update-counter ]; then
+                    cp .update-counter /tmp/.update-counter
+                  fi
 
                   git checkout --orphan pages
                   git reset --hard
 
                   cp /tmp/index.json index.json
+                  
+                  # 恢复更新计数器文件
+                  if [ -f /tmp/.update-counter ]; then
+                    cp /tmp/.update-counter .update-counter
+                  fi
 
                   echo "" > .nojekyll
-
-                  echo "$CUSTOM_DOMAIN" > CNAME
-
-                  git remote set-url origin git@github.com:${GITHUB_REPOSITORY}.git
-
+                  if [ -n "$CUSTOM_DOMAIN" ]; then
+                    echo "$CUSTOM_DOMAIN" > CNAME
+                  fi
+                  git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
                   git add -f index.json .nojekyll
-                  git add -f index.json CNAME .nojekyll
+                  # 添加更新计数器文件
+                  if [ -f .update-counter ]; then
+                    git add -f .update-counter
+                  fi
+                  if [ -f CNAME ]; then
+                    git add -f CNAME
+                  fi
                   git commit -m "Update market" || true
                   git push -f origin pages

--- a/src/config.js
+++ b/src/config.js
@@ -30,7 +30,7 @@ const defaults = {
         'https://koishi-registry.github.io/insecures/index.json',
 
     INCREMENTAL_UPDATE: "true", // 是否开启增量更新，否则每次都全量扫描
-    INCREMENTAL_UPDATE_TIMES: "3", // 每进行多少次增量更新后执行一次全量更新
+    INCREMENTAL_UPDATE_TIMES: "16", // 每进行多少次增量更新后执行一次全量更新  16代表4小时全量更新一次
     NPMJS_CONCURRENT_REQUESTS: 80, // npmjs.org 官方源的并发请求限制
 }
 

--- a/src/config.js
+++ b/src/config.js
@@ -30,6 +30,7 @@ const defaults = {
         'https://koishi-registry.github.io/insecures/index.json',
 
     INCREMENTAL_UPDATE: "true", // 是否开启增量更新，否则每次都全量扫描
+    INCREMENTAL_UPDATE_TIMES: "3", // 每进行多少次增量更新后执行一次全量更新
     NPMJS_CONCURRENT_REQUESTS: 80, // npmjs.org 官方源的并发请求限制
 }
 
@@ -75,5 +76,6 @@ export const config = {
     INCREMENTAL_UPDATE: process.env.INCREMENTAL_UPDATE
         ? process.env.INCREMENTAL_UPDATE.toLowerCase() === 'true'
         : defaults.INCREMENTAL_UPDATE === 'true',
+    INCREMENTAL_UPDATE_TIMES: parseInt(process.env.INCREMENTAL_UPDATE_TIMES || defaults.INCREMENTAL_UPDATE_TIMES, 10),
     NPMJS_CONCURRENT_REQUESTS: parseInt(process.env.NPMJS_CONCURRENT_REQUESTS || defaults.NPMJS_CONCURRENT_REQUESTS, 10),
 }

--- a/src/utils/update-counter.js
+++ b/src/utils/update-counter.js
@@ -1,0 +1,92 @@
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { execSync } from 'child_process'
+
+// 获取当前文件的目录
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+// 计数器文件名
+const COUNTER_FILENAME = '.update-counter'
+
+/**
+ * 从 pages 分支获取更新计数器
+ * @returns {number} 当前更新计数
+ */
+export function readUpdateCounter() {
+    try {
+        // 检查是否在 GitHub Actions 环境中
+        const isGitHubActions = process.env.GITHUB_ACTIONS === 'true'
+        
+        if (isGitHubActions) {
+            console.log('正在从 pages 分支获取更新计数...')
+            
+            try {
+                // 尝试从 pages 分支获取计数器文件
+                const counterContent = execSync('git fetch origin pages && git show origin/pages:.update-counter', { 
+                    stdio: ['pipe', 'pipe', 'pipe'],
+                    encoding: 'utf8' 
+                }).trim()
+                
+                const count = parseInt(counterContent, 10)
+                if (!isNaN(count)) {
+                    console.log(`从 pages 分支获取的更新计数: ${count}`)
+                    return count
+                }
+            } catch (error) {
+                console.log('无法从 pages 分支获取计数器，将使用默认值 0')
+            }
+            return 0
+        } else {
+            // 本地开发环境，使用本地文件
+            const localCounterPath = path.join(__dirname, '../../', COUNTER_FILENAME)
+            if (fs.existsSync(localCounterPath)) {
+                const count = parseInt(fs.readFileSync(localCounterPath, 'utf8').trim(), 10)
+                return isNaN(count) ? 0 : count
+            }
+        }
+    } catch (error) {
+        console.warn('读取更新计数器失败:', error.message)
+    }
+    
+    return 0
+}
+
+/**
+ * 准备更新计数器文件，以便在部署时保存到 pages 分支
+ * @param {number} count 当前计数
+ */
+export function prepareUpdateCounter(count) {
+    try {
+        // 将计数器保存到项目根目录，这样会被部署到 pages 分支
+        const counterPath = path.join(__dirname, '../../', COUNTER_FILENAME)
+        fs.writeFileSync(counterPath, count.toString(), 'utf8')
+        console.log(`更新计数器已准备好: ${count}`)
+        
+        // 如果在 GitHub Actions 中，确保文件会被部署
+        if (process.env.GITHUB_ACTIONS === 'true') {
+            // 在部署阶段，这个文件会被复制到 pages 分支
+            console.log('计数器文件将在部署阶段保存到 pages 分支')
+        }
+    } catch (error) {
+        console.error('准备更新计数器失败:', error.message)
+    }
+}
+
+/**
+ * 增加更新计数
+ * @returns {number} 更新后的计数
+ */
+export function incrementUpdateCounter() {
+    const currentCount = readUpdateCounter()
+    const newCount = currentCount + 1
+    prepareUpdateCounter(newCount)
+    return newCount
+}
+
+/**
+ * 重置更新计数器
+ */
+export function resetUpdateCounter() {
+    prepareUpdateCounter(0)
+    return 0
+}

--- a/src/utils/update-counter.js
+++ b/src/utils/update-counter.js
@@ -1,92 +1,102 @@
-import fs from 'fs'
-import path from 'path'
-import { fileURLToPath } from 'url'
-import { execSync } from 'child_process'
+import { getPluginsCollection } from './db.js'
 
-// 获取当前文件的目录
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
-// 计数器文件名
-const COUNTER_FILENAME = '.update-counter'
+// 在数据库中存储计数器的集合名称和文档ID
+const COUNTER_COLLECTION = 'system_settings'
+const COUNTER_DOCUMENT_ID = 'update_counter'
 
 /**
- * 从 pages 分支获取更新计数器
- * @returns {number} 当前更新计数
+ * 从数据库获取更新计数器
+ * @returns {Promise<number>} 当前更新计数
  */
-export function readUpdateCounter() {
+export async function readUpdateCounter() {
     try {
-        // 检查是否在 GitHub Actions 环境中
-        const isGitHubActions = process.env.GITHUB_ACTIONS === 'true'
+        console.log('正在从数据库获取更新计数...')
         
-        if (isGitHubActions) {
-            console.log('正在从 pages 分支获取更新计数...')
-            
-            try {
-                // 尝试从 pages 分支获取计数器文件
-                const counterContent = execSync('git fetch origin pages && git show origin/pages:.update-counter', { 
-                    stdio: ['pipe', 'pipe', 'pipe'],
-                    encoding: 'utf8' 
-                }).trim()
-                
-                const count = parseInt(counterContent, 10)
-                if (!isNaN(count)) {
-                    console.log(`从 pages 分支获取的更新计数: ${count}`)
-                    return count
-                }
-            } catch (error) {
-                console.log('无法从 pages 分支获取计数器，将使用默认值 0')
-            }
-            return 0
+        // 获取系统设置集合
+        const collection = await getPluginsCollection(COUNTER_COLLECTION)
+        
+        // 查询计数器文档
+        const counterDoc = await collection.findOne({ _id: COUNTER_DOCUMENT_ID })
+        
+        if (counterDoc && typeof counterDoc.count === 'number') {
+            console.log(`从数据库获取的更新计数: ${counterDoc.count}`)
+            return counterDoc.count
         } else {
-            // 本地开发环境，使用本地文件
-            const localCounterPath = path.join(__dirname, '../../', COUNTER_FILENAME)
-            if (fs.existsSync(localCounterPath)) {
-                const count = parseInt(fs.readFileSync(localCounterPath, 'utf8').trim(), 10)
-                return isNaN(count) ? 0 : count
-            }
+            console.log('数据库中没有找到计数器记录，将使用默认值 0')
+            return 0
         }
     } catch (error) {
         console.warn('读取更新计数器失败:', error.message)
+        return 0
     }
-    
-    return 0
 }
 
 /**
- * 准备更新计数器文件，以便在部署时保存到 pages 分支
+ * 将计数器保存到数据库
  * @param {number} count 当前计数
+ * @returns {Promise<number>} 保存后的计数
  */
-export function prepareUpdateCounter(count) {
+export async function saveUpdateCounter(count) {
     try {
-        // 将计数器保存到项目根目录，这样会被部署到 pages 分支
-        const counterPath = path.join(__dirname, '../../', COUNTER_FILENAME)
-        fs.writeFileSync(counterPath, count.toString(), 'utf8')
-        console.log(`更新计数器已准备好: ${count}`)
+        // 获取系统设置集合
+        const collection = await getPluginsCollection(COUNTER_COLLECTION)
         
-        // 如果在 GitHub Actions 中，确保文件会被部署
-        if (process.env.GITHUB_ACTIONS === 'true') {
-            // 在部署阶段，这个文件会被复制到 pages 分支
-            console.log('计数器文件将在部署阶段保存到 pages 分支')
-        }
+        // 更新或创建计数器文档
+        await collection.updateOne(
+            { _id: COUNTER_DOCUMENT_ID },
+            { 
+                $set: { 
+                    count: count,
+                    lastUpdated: new Date()
+                } 
+            },
+            { upsert: true }
+        )
+        
+        console.log(`更新计数器已保存到数据库: ${count}`)
+        return count
     } catch (error) {
-        console.error('准备更新计数器失败:', error.message)
+        console.error('保存更新计数器失败:', error.message)
+        return count
     }
 }
 
 /**
  * 增加更新计数
- * @returns {number} 更新后的计数
+ * @returns {Promise<number>} 更新后的计数
  */
-export function incrementUpdateCounter() {
-    const currentCount = readUpdateCounter()
-    const newCount = currentCount + 1
-    prepareUpdateCounter(newCount)
-    return newCount
+export async function incrementUpdateCounter() {
+    try {
+        // 获取系统设置集合
+        const collection = await getPluginsCollection(COUNTER_COLLECTION)
+        
+        // 使用原子操作增加计数
+        const result = await collection.findOneAndUpdate(
+            { _id: COUNTER_DOCUMENT_ID },
+            { 
+                $inc: { count: 1 },
+                $set: { lastUpdated: new Date() }
+            },
+            { 
+                upsert: true,
+                returnDocument: 'after'
+            }
+        )
+        
+        const newCount = result.value?.count || 1
+        console.log(`增量更新计数已更新: ${newCount}`)
+        return newCount
+    } catch (error) {
+        console.error('增加更新计数器失败:', error.message)
+        const currentCount = await readUpdateCounter()
+        return currentCount + 1
+    }
 }
 
 /**
  * 重置更新计数器
+ * @returns {Promise<number>} 重置后的计数 (0)
  */
-export function resetUpdateCounter() {
-    prepareUpdateCounter(0)
-    return 0
+export async function resetUpdateCounter() {
+    return await saveUpdateCounter(0)
 }

--- a/src/utils/update.js
+++ b/src/utils/update.js
@@ -4,7 +4,7 @@ import { loadCategories } from './categories.js'
 import { fetchWithRetry, fetchPackageDetails } from './fetcher.js'
 import semver from 'semver'
 import { loadInsecurePackages } from './insecure.js'
-import { readUpdateCounter, incrementUpdateCounter, resetUpdateCounter, prepareUpdateCounter } from './update-counter.js'
+import { readUpdateCounter, incrementUpdateCounter, resetUpdateCounter } from './update-counter.js'
 
 export async function checkForUpdates() {
     // 记录开始时间
@@ -14,7 +14,7 @@ export async function checkForUpdates() {
     let removedCount = 0
 
     // 读取当前更新计数
-    const currentCount = readUpdateCounter();
+    const currentCount = await readUpdateCounter();
     let newCount = currentCount;
     
     // 判断是否需要进行全量更新
@@ -29,13 +29,13 @@ export async function checkForUpdates() {
         } else {
             console.log(`已完成 ${currentCount} 次增量更新，根据配置进行全量更新，正在清空数据库...`);
             // 重置计数器
-            newCount = resetUpdateCounter();
+            newCount = await resetUpdateCounter();
         }
         await collection.deleteMany({}); // 清空所有文档
         console.log('数据库已清空。');
     } else {
         // 增加计数
-        newCount = incrementUpdateCounter();
+        newCount = await incrementUpdateCounter();
         console.log(`执行增量更新 (${newCount}/${config.INCREMENTAL_UPDATE_TIMES})`);
     }
 
@@ -202,9 +202,6 @@ export async function checkForUpdates() {
     const durationSeconds = durationMs / 1000; // 转换为秒
 
     console.log(`本次数据库更新总耗时：${durationSeconds.toFixed(2)} 秒`);
-    
-    // 确保计数器文件已准备好，以便在部署时保存到 pages 分支
-    prepareUpdateCounter(newCount);
 
     return updates.length + updatedCount + removedCount // 返回总更新/移除数量
 }


### PR DESCRIPTION
在每次运行时，从数据库获取当前计数

根据计数和配置决定是执行增量更新还是全量更新：
如果配置为全量更新（INCREMENTAL_UPDATE=false），直接进行全量更新
如果配置为增量更新（INCREMENTAL_UPDATE=true），但当前计数达到了设定的次数（INCREMENTAL_UPDATE_TIMES），也进行全量更新
否则，进行增量更新

在全量更新后重置计数器，在增量更新后增加计数
计数器的值保存在数据库中，确保在不同的运行之间保持状态
