### PR TITLE
Update fetcher.js - 处理仓库链接，移除 git+ 前缀

### DIFF
--- a/src/utils/fetcher.js
+++ b/src/utils/fetcher.js
@@ -219,14 +219,24 @@ export async function fetchPackageDetails(name, result) {
       ? `${config.NPM_PACKAGE_URL}/${name}`
       : `${config.NPM_PACKAGE_URL}/package/${name}`
 
+    // 处理仓库链接，移除 git+ 前缀
+    let repositoryUrl = ''
+    if (typeof versionInfo.repository === 'object') {
+      repositoryUrl = versionInfo.repository.url || ''
+    } else {
+      repositoryUrl = versionInfo.repository || ''
+    }
+    
+    // 移除 git+ 前缀
+    if (repositoryUrl.startsWith('git+')) {
+      repositoryUrl = repositoryUrl.substring(4)
+    }
+    
     const packageLinks = {
       npm: npmLink,
       bugs: versionInfo.bugs?.url || '',
       homepage: versionInfo.homepage || '',
-      repository:
-        typeof versionInfo.repository === 'object'
-          ? versionInfo.repository.url || ''
-          : versionInfo.repository || ''
+      repository: repositoryUrl
     }
 
     if (!packageLinks.bugs) {


### PR DESCRIPTION
比如 https://www.npmjs.com/package/koishi-plugin-javbus?activeTab=code

在镜像源里被构建成
```
        {
            "_id": "68a42dc7cccb2d63407c7afb",
            "package": {
                "name": "koishi-plugin-javbus",
                "keywords": [
                    "chatbot",
                    "koishi",
                    "plugin"
                ],
                "version": "1.0.9",
                "description": "查询javbus番号",
                "publisher": {
                    "name": "tediorelee",
                    "email": "tediorelee@gmail.com",
                    "username": "tediorelee"
                },
                "maintainers": [
                    {
                        "name": "tediorelee",
                        "email": "tediorelee@gmail.com",
                        "username": "tediorelee"
                    }
                ],
                "license": "MIT",
                "date": "2023-05-08T06:27:47.786Z",
                "links": {
                    "npm": "https://www.npmjs.com/package/koishi-plugin-javbus",
                    "repository": "git+https://github.com/tediorelee/koishi-plugin-javbus.git"
                },
                "contributors": []
            },
            "category": "media",
            "createdAt": "2022-11-06T08:13:06.117Z",
            "dependents": 0,
            "downloads": {
                "lastMonth": 536
            },
            "flags": {
                "insecure": 0
            },
            "ignored": false,
            "insecure": false,
            "installSize": 2423,
            "license": "MIT",
            "manifest": {
                "description": {
                    "zh": "查询javbus番号"
                }
            },
            "portable": false,
            "publishSize": 5518,
            "rating": 4.0249999999999995,
            "score": {
                "final": 4.0249999999999995,
                "detail": {
                    "quality": 7,
                    "popularity": 0,
                    "maintenance": 3.5
                }
            },
            "shortname": "javbus",
            "updated": "2023-05-08T06:27:53.063Z",
            "updatedAt": "2023-05-08T06:27:53.063Z",
            "verified": false
        },
```

---


从插件市场直接点击 访问的时候会跳转到  `git+https://github.com/tediorelee/koishi-plugin-javbus.git` 

从而导致打开的页面是  `about:blank` 

所以需要移除  `git+`  前缀

以优化跳转体验

---

