### PR TITLE
Update koishi-plugin-schema.json - 移除插件名称长度限制

### DIFF
--- a/src/schemas/koishi-plugin-schema.json
+++ b/src/schemas/koishi-plugin-schema.json
@@ -11,7 +11,7 @@
     "name": {
       "type": "string",
       "description": "Package name",
-      "pattern": "^(@koishijs\\/plugin-[a-zA-Z0-9]+(-[a-zA-Z0-9]+){0,4}|@[^/]+\\/koishi-plugin-[a-zA-Z0-9]+(-[a-zA-Z0-9]+){0,4}|koishi-plugin-[a-zA-Z0-9]+(-[a-zA-Z0-9]+){0,4})$"
+      "pattern": "^(@koishijs\\/plugin-[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*|@[^/]+\\/koishi-plugin-[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*|koishi-plugin-[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)$"
     },
     "version": {
       "type": "string",


### PR DESCRIPTION
koishi 文档 并没有对插件名称长度的限制

之前限制了长度必须为五个单词以内

但发现  https://www.npmjs.com/package/koishi-plugin-vercel-satori-png-service-font-source-han-mono-sc

此插件
```
koishi-plugin-vercel-satori-png-service-font-source-han-mono-sc
```

虽然长度超过五个部分

但是根据 https://koishi.chat/zh-CN/guide/develop/publish.html#%E5%8F%91%E5%B8%83%E6%8F%92%E4%BB%B6

koishi文档并没有限制包名长度

应该予以通过