### PR TITLE
Fix: 修复获取包详情时的 undefined 访问错误

### DIFF
--- a/src/utils/fetcher.ts
+++ b/src/utils/fetcher.ts
@@ -200,7 +200,13 @@ export async function fetchPackageDetails(
     const pkgData = (await fetchWithRetry(pkgUrl)) as NpmPackageData
 
     const latestVersion = pkgData['dist-tags']?.latest
-    const versionInfo = latestVersion ? pkgData.versions?.[latestVersion] : {}
+    const versionInfo = latestVersion ? pkgData.versions?.[latestVersion] : undefined
+
+    // 如果没有找到版本信息，跳过该包
+    if (!versionInfo) {
+      console.log(`Package ${name} has no version info, skipping.`)
+      return null
+    }
 
     // 检查包是否被弃用
     if (versionInfo.deprecated || pkgData.deprecated) {
@@ -280,18 +286,18 @@ export async function fetchPackageDetails(
 
     const contributors = Array.isArray(versionInfo.contributors)
       ? versionInfo.contributors.map(
-          (contributor: { name: any; email: any; url: any }) => {
-            if (typeof contributor === 'string') {
-              return { name: contributor }
-            }
-            return {
-              name: contributor.name || '',
-              email: contributor.email || '',
-              url: contributor.url || '',
-              username: contributor.name || ''
-            }
+        (contributor: { name: any; email: any; url: any }) => {
+          if (typeof contributor === 'string') {
+            return { name: contributor }
           }
-        )
+          return {
+            name: contributor.name || '',
+            email: contributor.email || '',
+            url: contributor.url || '',
+            username: contributor.name || ''
+          }
+        }
+      )
       : []
 
     const npmLink = name.startsWith('@')


### PR DESCRIPTION
## 问题描述

在 GitHub Actions 运行时，扫描插件时遇到以下错误：

https://github.com/Hoshino-Yumetsuki/koishi-registry/actions/runs/20689573142/job/59395621068#step:9:40

```
Error fetching koishi-plugin-adapter-yunhupro: TypeError: Cannot read properties of undefined (reading 'deprecated')
    at I (file:///home/runner/work/koishi-registry/koishi-registry/dist/index.js:1:13346)
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
    at async file:///home/runner/work/koishi-registry/koishi-registry/dist/index.js:1:18478
    at async Promise.all (index 28)
    at async U (file:///home/runner/work/koishi-registry/koishi-registry/dist/index.js:1:18507)
    at async q (file:///home/runner/work/koishi-registry/koishi-registry/dist/index.js:1:19531)
```

## 根本原因

在 `src/utils/fetcher.ts` 的 `fetchPackageDetails` 函数中：

```typescript
const latestVersion = pkgData['dist-tags']?.latest
const versionInfo = latestVersion ? pkgData.versions?.[latestVersion] : {}

// 检查包是否被弃用
if (versionInfo.deprecated || pkgData.deprecated) {
  return null
}
```

**问题分析：**

1. 当 `latestVersion` 存在但 `pkgData.versions[latestVersion]` 不存在时，可选链操作符 `?.` 会返回 `undefined`
2. 三元表达式中，虽然 `latestVersion` 为真，但 `pkgData.versions?.[latestVersion]` 可能返回 `undefined`
3. 这导致 `versionInfo` 实际上是 `undefined` 而不是预期的空对象 `{}`
4. 在访问 `versionInfo.deprecated` 时触发 `Cannot read properties of undefined` 错误

**触发场景：**

某些包（如 `koishi-plugin-adapter-yunhupro`）在 NPM registry 返回的数据中可能存在以下情况：
- `dist-tags.latest` 字段存在
- 但 `versions` 对象中缺少对应版本的详细信息
- 或者 `versions` 对象本身结构异常

## 解决方案

### 修改内容

在访问 `versionInfo` 的属性之前，添加明确的存在性检查：

```typescript
const latestVersion = pkgData['dist-tags']?.latest
const versionInfo = latestVersion ? pkgData.versions?.[latestVersion] : undefined

// 如果没有找到版本信息，跳过该包
if (!versionInfo) {
  console.log(`Package ${name} has no version info, skipping.`)
  return null
}

// 检查包是否被弃用
if (versionInfo.deprecated || pkgData.deprecated) {
  return null
}
```

### 改进点

1. **明确类型处理**：将 `versionInfo` 初始值从 `{}` 改为 `undefined`，更准确地反映实际情况
2. **提前检查**：在访问任何 `versionInfo` 属性之前，先验证其存在性
3. **友好日志**：当包缺少版本信息时，输出清晰的日志说明原因
4. **优雅降级**：遇到异常数据时跳过该包，而不是导致整个扫描流程崩溃

## 测试

- ✅ 修复后，程序能够正常处理缺少版本信息的包
- ✅ 对于 `koishi-plugin-adapter-yunhupro` 等问题包，会输出日志并跳过
- ✅ 不影响正常包的处理流程
- ✅ 避免了 GitHub Actions 运行时的崩溃

## 影响范围

- 仅影响 `fetchPackageDetails` 函数的错误处理逻辑
- 对正常包的处理流程无影响
- 提高了程序的健壮性和容错能力

## 相关文件

- `src/utils/fetcher.ts` - 修复 `versionInfo` 的 undefined 访问问题
